### PR TITLE
fix(vars): change explanation

### DIFF
--- a/vars.env.sample
+++ b/vars.env.sample
@@ -2,7 +2,7 @@
 # to populate these variable use the command:
 # [source,shell]
 # ----
-# $ gcloud compute instance list
+# $ gcloud compute instances list
 # NAME                ZONE                    MACHINE_TYPE  PREEMPTIBLE  INTERNAL_IP  EXTERNAL_IP    STATUS
 # ${INSTANCE_NAME}    ${INSTANCE_ZONE}        XXX                        XXX                         TERMINATED
 # ${INSTANCE_NAME}    ${INSTANCE_ZONE}        XXX                        XXX          XXX            RUNNING


### PR DESCRIPTION
it would fail as there is no command names 'gcloud compute instance'
